### PR TITLE
add lures to stat board

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -165,6 +165,11 @@ class Admin(commands.Cog):
                 stats.append("egg_active")
             elif "stop" in stat:
                 stats.append("stop_amount")
+            elif "lure" in stat:
+                if "amount" in stat:
+                    stats.append("lure_amount")
+                elif "types" in stat:
+                    stats.append("lure_types")
             elif "grunt" in stat:
                 #if "active" in stat:
                 stats.append("grunt_active")

--- a/cogs/boards.py
+++ b/cogs/boards.py
@@ -159,6 +159,15 @@ class Boards(commands.Cog):
                         text = f"{text} ({quest_ratio}%)"
                     text = text + "\n"
 
+                if "lure_amount" in board['type']:
+                    lure_active = await queries.statboard_lure_active(self.bot.config, area[0])
+                    text = f"{text}{self.bot.custom_emotes['lure']} **{lure_active[0][0]:,}** {self.bot.locale['active_lures']}\n"
+
+                if "lure_types" in board['type']:
+                    if not "lure_amount" in board['type']: #don't run query twice if lure_amount in board type
+                        lure_active = await queries.statboard_lure_active(self.bot.config, area[0])
+                    text = f"{text}{self.bot.custom_emotes['lure_normal']}**{lure_active[0][1]}**{self.bot.custom_emotes['blank']}{self.bot.custom_emotes['lure_glacial']}**{lure_active[0][2]}**{self.bot.custom_emotes['blank']}{self.bot.custom_emotes['lure_mossy']}**{lure_active[0][3]}**{self.bot.custom_emotes['blank']}{self.bot.custom_emotes['lure_magnetic']}**{lure_active[0][4]}**\n\n"
+
                 if "grunt_active" in board['type']:
                     grunt_active = await queries.statboard_grunt_active(self.bot.config, area[0])
                     if not "leader_active" in board['type']:

--- a/data/dts/de.json
+++ b/data/dts/de.json
@@ -30,6 +30,7 @@
     "active_pokemon": "Aktive Pokémon",
     "active_grunts": "Aktive Rüpel",
     "active_eggs": "Aktive Eier",
+    "active_lures": "Aktive Lockmodule",
     "between": "zwischen",
     "and": "und",
     "stats": "Statistiken",

--- a/data/dts/en.json
+++ b/data/dts/en.json
@@ -30,6 +30,7 @@
     "active_pokemon": "Active Pokémon",
     "active_grunts": "Active Grunts",
     "active_eggs": "Active Eggs",
+    "active_lures": "Active Lures",
     "between": "between",
     "and": "and",
     "stats": "Statistics",

--- a/data/dts/es.json
+++ b/data/dts/es.json
@@ -30,6 +30,7 @@
     "active_pokemon": "Pokémon Activos",
     "active_grunts": "Reclutas Active",
     "active_eggs": "Huevos activos",
+    "active_lures": "Cebos Activos",
     "between": "entre",
     "and": "y",
     "stats": "Estadísitcas",

--- a/data/dts/fr.json
+++ b/data/dts/fr.json
@@ -30,6 +30,7 @@
     "active_pokemon": "Pokémon actives",
     "active_grunts": "Sbires",
     "active_eggs": "Œufs en cours ",
+    "active_lures": "Active Lures",
     "between": "entre le",
     "and": "au",
     "stats": "Statistiques",

--- a/data/dts/pl.json
+++ b/data/dts/pl.json
@@ -30,6 +30,7 @@
     "active_pokemon": "Aktywne Pokemony",
     "active_grunts": "Aktywne Inwazje",
     "active_eggs": "Aktywne Raidy niewyklute",
+    "active_lures": "Active Lures",
     "between": "pomiędzy",
     "and": "i",
     "stats": "Statystyki",

--- a/util/queries.py
+++ b/util/queries.py
@@ -187,6 +187,17 @@ async def statboard_stop_amount(config, area):
     await cursor_statboard_stop_amount.close()
     return statboard_stop_amount
 
+async def statboard_lure_active(config, area):
+    cursor_statboard_lure_active = await connect_db(config)
+    if config['db_scan_schema'] == "mad":
+        await cursor_statboard_lure_active.execute(f"select count(pokestop_id), ifnull(sum(active_fort_modifier = 501), 0), ifnull(sum(active_fort_modifier = 502), 0), ifnull(sum(active_fort_modifier = 503), 0), ifnull(sum(active_fort_modifier = 504), 0) from pokestop where lure_expiration > UTC_TIMESTAMP() and ST_CONTAINS(ST_GEOMFROMTEXT('POLYGON(({area}))'), point(latitude, longitude))")
+    elif config['db_scan_schema'] == "rdm":
+        await cursor_statboard_lure_active.execute(f"select count(id), ifnull(sum(lure_id = 501), 0), ifnull(sum(lure_id = 502), 0), ifnull(sum(lure_id = 503), 0), ifnull(sum(lure_id = 504), 0) from pokestop where lure_expire_timestamp is not NULL and ST_CONTAINS(ST_GEOMFROMTEXT('POLYGON(({area}))'), point(lat, lon))")
+    statboard_lure_active = await cursor_statboard_lure_active.fetchall()
+
+    await cursor_statboard_lure_active.close()
+    return statboard_lure_active
+
 async def statboard_grunt_active(config, area):
     cursor_statboard_grunt_active = await connect_db(config)
     if config['db_scan_schema'] == "mad":


### PR DESCRIPTION
You can add lure stats to your stats board. 
show total amount of lures with `lure amount`
show different types of lures with `lure types`

need to be tested with mad db
missing translation of 'active_lures' in es, fr, pl

if you want to test the pr, you have to add this images to your trash server and add them in your config/emotes.json with name and id like: 
```
    "lure": "<:lure:emote_id_0>",
    "lure_normal": "<:lure_normal:emote_id_1>",
    "lure_glacial": "<:lure_glacial:emote_id_2>",
    "lure_mossy": "<:lure_mossy:emote_id_3>",
    "lure_magnetic": "<:lure_magnetic:emote_id_4>",
```
i created a white lure modul to have a neutral lure icon :D

![lure](https://user-images.githubusercontent.com/65044707/81456457-a05e2a80-9192-11ea-90d7-f4e34c6d8df2.png)
![lure_normal](https://user-images.githubusercontent.com/65044707/81456435-8cb2c400-9192-11ea-9e40-87847c45119f.png)
![lure_magnetic](https://user-images.githubusercontent.com/65044707/81456436-8d4b5a80-9192-11ea-9280-816310dbe026.png)
![lure_mossy](https://user-images.githubusercontent.com/65044707/81456437-8d4b5a80-9192-11ea-896d-c56cca8ff28a.png)
![lure_glacial](https://user-images.githubusercontent.com/65044707/81456438-8d4b5a80-9192-11ea-8d27-b194c09465f1.png)

thats how it will look like:
![ss (2020-05-09 at 01 06 01)](https://user-images.githubusercontent.com/65044707/81456563-0c409300-9193-11ea-8e46-a0cec34aa680.png)
![ss (2020-05-09 at 01 20 38)](https://user-images.githubusercontent.com/65044707/81456622-50339800-9193-11ea-9482-4698778e9e6a.png)



