### PR TITLE
add white gym to stat board

### DIFF
--- a/cogs/boards.py
+++ b/cogs/boards.py
@@ -129,7 +129,7 @@ class Boards(commands.Cog):
                 
                 if "gym_amount" in board['type']:
                     gym_amount = await queries.statboard_gym_amount(self.bot.config, area[0])
-                    text = f"{text}{self.bot.custom_emotes['gym_white']} **{gym_amount[0][0]:,}** {self.bot.locale['total_gyms']}\n"
+                    text = f"{text}{self.bot.custom_emotes['gym_grey']}**{gym_amount[0][0]:,}** {self.bot.locale['total_gyms']}\n"
 
                 if "raid_active" in board['type']:
                     raid_active = await queries.statboard_raid_active(self.bot.config, area[0])
@@ -145,7 +145,7 @@ class Boards(commands.Cog):
                 
                 if "gym_teams" in board['type']:
                     gym_teams = await queries.statboard_gym_teams(self.bot.config, area[0])
-                    text = f"{text}{self.bot.custom_emotes['gym_blue']}**{gym_teams[0][1]}**{self.bot.custom_emotes['blank']}{self.bot.custom_emotes['gym_red']}**{gym_teams[0][2]}**{self.bot.custom_emotes['blank']}{self.bot.custom_emotes['gym_yellow']}**{gym_teams[0][3]}**\n"
+                    text = f"{text}{self.bot.custom_emotes['gym_blue']}**{gym_teams[0][1]}**{self.bot.custom_emotes['blank']}{self.bot.custom_emotes['gym_red']}**{gym_teams[0][2]}**{self.bot.custom_emotes['blank']}{self.bot.custom_emotes['gym_yellow']}**{gym_teams[0][3]}**{self.bot.custom_emotes['blank']}{self.bot.custom_emotes['gym_white']}**{gym_teams[0][0]}**\n"
 
                 if "stop_amount" in board['type']:
                     stop_amount = await queries.statboard_stop_amount(self.bot.config, area[0])

--- a/util/queries.py
+++ b/util/queries.py
@@ -146,9 +146,9 @@ async def statboard_gym_amount(config, area):
 async def statboard_gym_teams(config, area):
     cursor_statboard_gym_teams = await connect_db(config)
     if config['db_scan_schema'] == "mad":
-        await cursor_statboard_gym_teams.execute(f"select sum(team_id = 0), sum(team_id = 1), sum(team_id=2), sum(team_id=3) from gym where ST_CONTAINS(ST_GEOMFROMTEXT('POLYGON(({area}))'), point(latitude, longitude))")
+        await cursor_statboard_gym_teams.execute(f"select ifnull(sum(team_id = 0),0), ifnull(sum(team_id = 1),0), ifnull(sum(team_id=2),0), ifnull(sum(team_id=3),0) from gym where ST_CONTAINS(ST_GEOMFROMTEXT('POLYGON(({area}))'), point(latitude, longitude))")
     elif config['db_scan_schema'] == "rdm":
-        await cursor_statboard_gym_teams.execute(f"select sum(team_id = 0), sum(team_id = 1), sum(team_id=2), sum(team_id=3) from gym where ST_CONTAINS(ST_GEOMFROMTEXT('POLYGON(({area}))'), point(lat, lon))")
+        await cursor_statboard_gym_teams.execute(f"select ifnull(sum(team_id = 0),0), ifnull(sum(team_id = 1),0), ifnull(sum(team_id=2),0), ifnull(sum(team_id=3),0) from gym where ST_CONTAINS(ST_GEOMFROMTEXT('POLYGON(({area}))'), point(lat, lon))")
     statboard_gym_teams = await cursor_statboard_gym_teams.fetchall()
 
     await cursor_statboard_gym_teams.close()


### PR DESCRIPTION
This commit adds neutral gyms to stat board gym_teams.
The statboard_gym_teams query already gets the neutral gym amount, but didnt used them in boards.py.

I also added ifnull() to the query, because sum() will return a Nonetype, if there are no gyms of a team. This would break the f-string formating in boards.py

To test the PR you have to manually add the emote to your trashserver and add it in your config/emotes.json

`	"gym_grey": "<:gym_grey:emote_ID>",
`

Added a grey gym emote, since white gym is used for neutral gyms
![gym_grey](https://user-images.githubusercontent.com/65044707/81481808-eff43300-9232-11ea-87bd-d47448cf8632.png)

![ss (2020-05-09 at 08 20 03)](https://user-images.githubusercontent.com/65044707/81481842-27fb7600-9233-11ea-866e-5760d4cccbb9.png)

