### PR TITLE
Simpler alt table / less frequent table updates

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -88,7 +88,7 @@ class Admin(commands.Cog):
             await message.edit(embed=embed)
             return
         await ctx.message.delete()
-        self.bot.boards['raids'].append({"channel_id": message.channel.id, "message_id": message.id, "title": self.bot.locale['raids'], "area": area, "timezone": self.bot.config['timezone'], "wait": 15, "levels": level_list, "ex": False})
+        self.bot.boards['raids'].append({"channel_id": message.channel.id, "message_id": message.id, "title": self.bot.locale['raids'], "area": area, "timezone": self.bot.config['timezone'], "wait": 65, "levels": level_list, "ex": False})
 
         with open("config/boards.json", "w") as f:
             f.write(json.dumps(self.bot.boards, indent=4))
@@ -124,7 +124,7 @@ class Admin(commands.Cog):
             await message.edit(embed=embed)
             return
         await ctx.message.delete()
-        self.bot.boards['eggs'].append({"channel_id": message.channel.id, "message_id": message.id, "title": self.bot.locale['eggs'], "area": area, "timezone": self.bot.config['timezone'], "wait": 15, "levels": level_list, "ex": False})
+        self.bot.boards['eggs'].append({"channel_id": message.channel.id, "message_id": message.id, "title": self.bot.locale['eggs'], "area": area, "timezone": self.bot.config['timezone'], "wait": 65, "levels": level_list, "ex": False})
 
         with open("config/boards.json", "w") as f:
             f.write(json.dumps(self.bot.boards, indent=4))
@@ -266,7 +266,7 @@ class Admin(commands.Cog):
             await message.edit(embed=embed)
             return
         await ctx.message.delete()
-        self.bot.boards['stats'].append({"channel_id": message.channel.id, "message_id": message.id, "title": self.bot.locale['stats'], "area": area, "timezone": self.bot.config['timezone'], "wait": 15, "type": stats})
+        self.bot.boards['stats'].append({"channel_id": message.channel.id, "message_id": message.id, "title": self.bot.locale['stats'], "area": area, "timezone": self.bot.config['timezone'], "wait": 65, "type": stats})
 
         with open("config/boards.json", "w") as f:
             f.write(json.dumps(self.bot.boards, indent=4))
@@ -306,7 +306,7 @@ class Admin(commands.Cog):
             return
 
         await ctx.message.delete()
-        self.bot.boards['raid_channels'].append({"channel_id": channel.id, "area": area, "timezone": self.bot.config['timezone'], "wait": 15, "levels": level_list})
+        self.bot.boards['raid_channels'].append({"channel_id": channel.id, "area": area, "timezone": self.bot.config['timezone'], "wait": 65, "levels": level_list})
 
         with open("config/boards.json", "w") as f:
             f.write(json.dumps(self.bot.boards, indent=4))

--- a/util/config.py
+++ b/util/config.py
@@ -52,12 +52,6 @@ def create_config(config_path):
     # alt DB for pokemon#
 
     config['use_alt_table_for_pokemon'] = config_raw.getboolean('alternative_table_for_pokemon','use_alt_table_for_pokemon')
-    config['alt_db_scan_schema'] = config_raw.get('alternative_table_for_pokemon','alt_scanner_db_schema')
-    config['alt_db_host'] = config_raw.get('alternative_table_for_pokemon','alt_host')
-    config['alt_db_port'] = config_raw.getint('alternative_table_for_pokemon','alt_port')
-    config['alt_db_user'] = config_raw.get('alternative_table_for_pokemon','alt_user')
-    config['alt_db_pass'] = config_raw.get('alternative_table_for_pokemon','alt_password')
-    config['alt_db_dbname'] = config_raw.get('alternative_table_for_pokemon','alt_scanner_db_name')
     config['alt_pokemon_table'] = config_raw.get('alternative_table_for_pokemon', 'alt_pokemon_table')
     config['alt_shiny_table'] = config_raw.get('alternative_table_for_pokemon', 'alt_shiny_table')
 


### PR DESCRIPTION
Changed the default new board update time to 65 instead of 15.

Removed all traces of alt database support.  It is only used for alt table now.  Which is usually pokemon_history if it's in a different db on the same server then put in "dbname.tablename" instead